### PR TITLE
Refactor: is market listed for core pool logic

### DIFF
--- a/contracts/Interfaces/IComptroller.sol
+++ b/contracts/Interfaces/IComptroller.sol
@@ -5,4 +5,6 @@ interface IComptroller {
     function isComptroller() external view returns (bool);
 
     function markets(address) external view returns (bool);
+
+    function getAllMarkets() external view returns (address[] memory);
 }

--- a/contracts/TokenConverter/RiskFundConverter.sol
+++ b/contracts/TokenConverter/RiskFundConverter.sol
@@ -48,7 +48,7 @@ contract RiskFundConverter is AbstractTokenConverter {
     event AssetTransferredToDestination(address indexed comptroller, address indexed asset, uint256 amount);
 
     // Event emitted after the poolsAssetsDirectTransfer mapping is updated
-    event PoolAssetsDirectTransferUpdated(address indexed comptrollers, address indexed assets);
+    event PoolAssetsDirectTransferUpdated(address indexed comptroller, address indexed asset, bool value);
 
     // Error thrown when comptrollers array length is not equal to assets array length
     error InvalidArguments();
@@ -80,7 +80,7 @@ contract RiskFundConverter is AbstractTokenConverter {
         address[][] calldata assets,
         bool[][] calldata values
     ) external {
-        _checkAccessAllowed("setPoolsAssetsDirectTransfer(address[], address[][], bool[][])");
+        _checkAccessAllowed("setPoolsAssetsDirectTransfer(address[],address[][],bool[][])");
 
         uint256 comptrollersLength = comptrollers.length;
 
@@ -98,7 +98,7 @@ contract RiskFundConverter is AbstractTokenConverter {
 
             for (uint256 j; j < poolAssets.length; ++j) {
                 poolsAssetsDirectTransfer[comptrollers[i]][poolAssets[j]] = assetsValues[j];
-                emit PoolAssetsDirectTransferUpdated(comptrollers[i], poolAssets[j]);
+                emit PoolAssetsDirectTransferUpdated(comptrollers[i], poolAssets[j], assetsValues[j]);
             }
         }
     }

--- a/tests/TokenConverter/RiskFundConverter.ts
+++ b/tests/TokenConverter/RiskFundConverter.ts
@@ -10,6 +10,7 @@ import {
   IAccessControlManagerV8,
   IComptroller,
   IPoolRegistry,
+  IVToken,
   MockDeflatingToken,
   MockDeflatingToken__factory,
   MockRiskFundConverter,
@@ -37,6 +38,7 @@ let corePool: FakeContract<IComptroller>;
 let poolA: FakeContract<IComptroller>;
 let poolB: FakeContract<IComptroller>;
 let poolC: FakeContract<IComptroller>;
+let vToken: FakeContract<IVToken>;
 
 async function fixture(): Promise<void> {
   [, unKnown] = await ethers.getSigners();
@@ -49,6 +51,7 @@ async function fixture(): Promise<void> {
   poolA = await smock.fake<IComptroller>("IComptroller");
   poolB = await smock.fake<IComptroller>("IComptroller");
   poolC = await smock.fake<IComptroller>("IComptroller");
+  vToken = await smock.fake<IVToken>("IVToken");
 
   accessControl = await smock.fake<IAccessControlManagerV8>("IAccessControlManagerV8");
   oracle = await smock.fake<ResilientOracleInterface>("ResilientOracleInterface");
@@ -120,7 +123,8 @@ describe("Risk fund Converter: tests", () => {
     await tokenIn.transfer(poolB.address, POOL_B_AMOUNT);
     await tokenIn.transfer(poolC.address, POOL_C_AMOUNT);
     await tokenIn.transfer(corePool.address, CORE_POOL_AMOUNT);
-    corePool.markets.returns(true);
+    vToken.underlying.returns(tokenIn.address);
+    corePool.getAllMarkets.returns([vToken.address]);
 
     await converter.setVariable("poolsAssetsReserves", {
       [poolA.address]: {

--- a/tests/TokenConverter/RiskFundConverter.ts
+++ b/tests/TokenConverter/RiskFundConverter.ts
@@ -208,7 +208,7 @@ describe("Risk fund Converter: tests", () => {
 
       await expect(converter.setPoolsAssetsDirectTransfer([poolA.address], [[tokenIn.address]], [[true]]))
         .to.emit(converter, "PoolAssetsDirectTransferUpdated")
-        .withArgs(poolA.address, tokenIn.address);
+        .withArgs(poolA.address, tokenIn.address, true);
 
       expect(await converter.poolsAssetsDirectTransfer(poolA.address, tokenIn.address)).to.equal(true);
     });

--- a/tests/TokenConverter/RiskFundConverter.ts
+++ b/tests/TokenConverter/RiskFundConverter.ts
@@ -175,7 +175,7 @@ describe("Risk fund Converter: tests", () => {
       await accessControl.isAllowedToCall.returns(false);
 
       await expect(
-        converter.setPoolsAssetsDirectTransfer([poolA.address], [[tokenIn.address]]),
+        converter.setPoolsAssetsDirectTransfer([poolA.address], [[tokenIn.address]], [[true]]),
       ).to.be.revertedWithCustomError(converter, "Unauthorized");
     });
 
@@ -183,14 +183,30 @@ describe("Risk fund Converter: tests", () => {
       await accessControl.isAllowedToCall.returns(true);
 
       await expect(
-        converter.setPoolsAssetsDirectTransfer([poolA.address], [[tokenIn.address], [tokenIn.address]]),
-      ).to.be.revertedWithCustomError(converter, "InvalidComptrollersAndAssets");
+        converter.setPoolsAssetsDirectTransfer(
+          [poolA.address, poolB.address],
+          [[tokenIn.address], [tokenIn.address]],
+          [[true]],
+        ),
+      ).to.be.revertedWithCustomError(converter, "InvalidArguments");
+
+      await expect(
+        converter.setPoolsAssetsDirectTransfer([poolA.address], [[tokenIn.address], [tokenIn.address]], [[true]]),
+      ).to.be.revertedWithCustomError(converter, "InvalidArguments");
+
+      await expect(
+        converter.setPoolsAssetsDirectTransfer([poolA.address], [[tokenIn.address, tokenIn.address]], [[true]]),
+      ).to.be.revertedWithCustomError(converter, "InvalidArguments");
+
+      await expect(
+        converter.setPoolsAssetsDirectTransfer([poolA.address], [[tokenIn.address]], [[true, true]]),
+      ).to.be.revertedWithCustomError(converter, "InvalidArguments");
     });
 
     it("Success on the setPoolsAssetsDirectTransfer", async () => {
       await accessControl.isAllowedToCall.returns(true);
 
-      await expect(converter.setPoolsAssetsDirectTransfer([poolA.address], [[tokenIn.address]]))
+      await expect(converter.setPoolsAssetsDirectTransfer([poolA.address], [[tokenIn.address]], [[true]]))
         .to.emit(converter, "PoolAssetsDirectTransferUpdated")
         .withArgs(poolA.address, tokenIn.address);
 
@@ -208,7 +224,7 @@ describe("Risk fund Converter: tests", () => {
       expect(await tokenIn.balanceOf(riskFund.address)).to.equal(0);
       expect(await tokenIn.balanceOf(converter.address)).to.equal(0);
       await tokenIn.transfer(converter.address, POOL_A_AMOUNT);
-      await converter.setPoolsAssetsDirectTransfer([poolA.address], [[tokenIn.address]]);
+      await converter.setPoolsAssetsDirectTransfer([poolA.address], [[tokenIn.address]], [[true]]);
       await converter.updateAssetsState(poolA.address, tokenIn.address);
 
       expect(await tokenIn.balanceOf(converter.address)).to.equal(0);


### PR DESCRIPTION
- Refactored the logic for the isAssetListed in any market of the core pool.
- Refactored the `setPoolsAssetsDirectTransfer` method
