### PR TITLE
[VEN-2212]: Fix for MAX_PERCENT in PSR

### DIFF
--- a/contracts/ProtocolReserve/ProtocolShareReserve.sol
+++ b/contracts/ProtocolReserve/ProtocolShareReserve.sol
@@ -36,7 +36,7 @@ contract ProtocolShareReserve is
     struct DistributionConfig {
         Schema schema;
         /// @dev percenatge is represented without any scale
-        uint8 percentage;
+        uint16 percentage;
         address destination;
     }
 
@@ -55,7 +55,7 @@ contract ProtocolShareReserve is
     /// @notice address of pool registry contract
     address public poolRegistry;
 
-    uint8 public constant MAX_PERCENT = 100;
+    uint16 public constant MAX_PERCENT = 1e4;
 
     /// @notice comptroller => asset => schema => balance
     mapping(address => mapping(address => mapping(Schema => uint256))) public assetsReserves;
@@ -99,16 +99,16 @@ contract ProtocolShareReserve is
     /// @notice Event emitted when distribution configuration is updated
     event DistributionConfigUpdated(
         address indexed destination,
-        uint8 oldPercentage,
-        uint8 newPercentage,
+        uint16 oldPercentage,
+        uint16 newPercentage,
         Schema schema
     );
 
     /// @notice Event emitted when distribution configuration is added
-    event DistributionConfigAdded(address indexed destination, uint8 percentage, Schema schema);
+    event DistributionConfigAdded(address indexed destination, uint16 percentage, Schema schema);
 
     /// @notice Event emitted when distribution configuration is removed
-    event DistributionConfigRemoved(address indexed destination, uint8 percentage, Schema schema);
+    event DistributionConfigRemoved(address indexed destination, uint16 percentage, Schema schema);
 
     /**
      * @dev Constructor to initialize the immutable variables
@@ -424,7 +424,7 @@ contract ProtocolShareReserve is
      */
     function _ensurePercentages() internal view {
         uint256 totalSchemas = uint256(type(Schema).max) + 1;
-        uint8[] memory totalPercentages = new uint8[](totalSchemas);
+        uint16[] memory totalPercentages = new uint16[](totalSchemas);
 
         uint256 distributionTargetsLength = distributionTargets.length;
         for (uint256 i = 0; i < distributionTargetsLength; ) {

--- a/tests/ProtocolShareReserve.ts
+++ b/tests/ProtocolShareReserve.ts
@@ -99,32 +99,32 @@ const configureDistribution = async (setup: SetupProtocolShareReserveFixture) =>
   await setup.protocolShareReserve.addOrUpdateDistributionConfigs([
     {
       schema: SCHEMA_PROTOCOL_RESERVE,
-      percentage: 40,
+      percentage: 4000,
       destination: setup.riskFundSwapper.address,
     },
     {
       schema: SCHEMA_PROTOCOL_RESERVE,
-      percentage: 20,
+      percentage: 2000,
       destination: setup.xvsVaultSwapper.address,
     },
     {
       schema: SCHEMA_PROTOCOL_RESERVE,
-      percentage: 40,
+      percentage: 4000,
       destination: setup.dao.address,
     },
     {
       schema: SCHEMA_ADDITIONAL_REVENUE,
-      percentage: 48,
+      percentage: 4800,
       destination: setup.riskFundSwapper.address,
     },
     {
       schema: SCHEMA_ADDITIONAL_REVENUE,
-      percentage: 26,
+      percentage: 2600,
       destination: setup.xvsVaultSwapper.address,
     },
     {
       schema: SCHEMA_ADDITIONAL_REVENUE,
-      percentage: 26,
+      percentage: 2600,
       destination: setup.dao.address,
     },
   ]);
@@ -152,27 +152,27 @@ describe("ProtocolShareReserve: Tests", function () {
 
     expect(config1.schema).to.equal(SCHEMA_PROTOCOL_RESERVE);
     expect(config1.destination).to.equal(setup.riskFundSwapper.address);
-    expect(config1.percentage).to.equal(40);
+    expect(config1.percentage).to.equal(4000);
 
     expect(config2.schema).to.equal(SCHEMA_PROTOCOL_RESERVE);
     expect(config2.destination).to.equal(setup.xvsVaultSwapper.address);
-    expect(config2.percentage).to.equal(20);
+    expect(config2.percentage).to.equal(2000);
 
     expect(config3.schema).to.equal(SCHEMA_PROTOCOL_RESERVE);
     expect(config3.destination).to.equal(setup.dao.address);
-    expect(config3.percentage).to.equal(40);
+    expect(config3.percentage).to.equal(4000);
 
     expect(config4.schema).to.equal(SCHEMA_ADDITIONAL_REVENUE);
     expect(config4.destination).to.equal(setup.riskFundSwapper.address);
-    expect(config4.percentage).to.equal(48);
+    expect(config4.percentage).to.equal(4800);
 
     expect(config5.schema).to.equal(SCHEMA_ADDITIONAL_REVENUE);
     expect(config5.destination).to.equal(setup.xvsVaultSwapper.address);
-    expect(config5.percentage).to.equal(26);
+    expect(config5.percentage).to.equal(2600);
 
     expect(config6.schema).to.equal(SCHEMA_ADDITIONAL_REVENUE);
     expect(config6.destination).to.equal(setup.dao.address);
-    expect(config6.percentage).to.equal(26);
+    expect(config6.percentage).to.equal(2600);
   });
 
   it("update configuration of schemas", async () => {
@@ -181,7 +181,7 @@ describe("ProtocolShareReserve: Tests", function () {
       protocolShareReserve.addOrUpdateDistributionConfigs([
         {
           schema: SCHEMA_PROTOCOL_RESERVE,
-          percentage: 30,
+          percentage: 3000,
           destination: signers[0].address,
         },
       ]),
@@ -190,12 +190,12 @@ describe("ProtocolShareReserve: Tests", function () {
     await protocolShareReserve.addOrUpdateDistributionConfigs([
       {
         schema: SCHEMA_PROTOCOL_RESERVE,
-        percentage: 30,
+        percentage: 3000,
         destination: setup.riskFundSwapper.address,
       },
       {
         schema: SCHEMA_PROTOCOL_RESERVE,
-        percentage: 30,
+        percentage: 3000,
         destination: setup.xvsVaultSwapper.address,
       },
     ]);
@@ -204,7 +204,7 @@ describe("ProtocolShareReserve: Tests", function () {
 
     expect(config1.schema).to.equal(SCHEMA_PROTOCOL_RESERVE);
     expect(config1.destination).to.equal(setup.riskFundSwapper.address);
-    expect(config1.percentage).to.equal(30);
+    expect(config1.percentage).to.equal(3000);
   });
 
   it("remove configuration", async () => {


### PR DESCRIPTION
## Description

This PR contains fix regarding `MAX_PERCENT` used when executing `addOrUpdateDistributionConfigs()` for defining the percentage to transfer amounts to destinations.

Resolves #VEN-2212

