### PR TITLE
fix: set deployer as owner in non live networks

### DIFF
--- a/deploy/1-deploy.ts
+++ b/deploy/1-deploy.ts
@@ -24,7 +24,7 @@ const func: DeployFunction = async ({
     deterministicDeployment: false,
     args: [comptrollerAddress, WBNBAddress, vBNBAddress],
     proxy: {
-      owner: timelockAddress,
+      owner: live ? timelockAddress : deployer,
       proxyContract: "OpenZeppelinTransparentProxy",
       execute: {
         methodName: "initialize",


### PR DESCRIPTION
## Description

For convenience set the owner of PSR as deployer when deploying to non live network
