### PR TITLE
feat: migrate to 0.8.20

### DIFF
--- a/contracts/Interfaces/IComptroller.sol
+++ b/contracts/Interfaces/IComptroller.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity ^0.8.20;
 
 interface IComptroller {
     function isComptroller() external view returns (bool);

--- a/contracts/Interfaces/IConverterNetwork.sol
+++ b/contracts/Interfaces/IConverterNetwork.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity ^0.8.20;
 
 import { IAbstractTokenConverter } from "../TokenConverter/IAbstractTokenConverter.sol";
 

--- a/contracts/Interfaces/IIncomeDestination.sol
+++ b/contracts/Interfaces/IIncomeDestination.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity ^0.8.20;
 
 interface IIncomeDestination {
     function updateAssetsState(address comptroller, address asset) external;

--- a/contracts/Interfaces/IPoolRegistry.sol
+++ b/contracts/Interfaces/IPoolRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity ^0.8.20;
 
 interface IPoolRegistry {
     /// @notice Get VToken in the Pool for an Asset

--- a/contracts/Interfaces/IProtocolShareReserve.sol
+++ b/contracts/Interfaces/IProtocolShareReserve.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity ^0.8.20;
 
 interface IProtocolShareReserve {
     /// @notice it represents the type of vToken income

--- a/contracts/Interfaces/IRiskFund.sol
+++ b/contracts/Interfaces/IRiskFund.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity ^0.8.20;
 
 /**
  * @title IRiskFund

--- a/contracts/Interfaces/IRiskFundConverter.sol
+++ b/contracts/Interfaces/IRiskFundConverter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity ^0.8.20;
 
 interface IRiskFundConverter {
     function updateAssetsState(address comptroller, address asset) external;

--- a/contracts/Interfaces/IShortfall.sol
+++ b/contracts/Interfaces/IShortfall.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity ^0.8.20;
 
 /**
  * @title IShortfall

--- a/contracts/Interfaces/IVToken.sol
+++ b/contracts/Interfaces/IVToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity ^0.8.20;
 
 interface IVToken {
     function underlying() external view returns (address);

--- a/contracts/Interfaces/IXVSVault.sol
+++ b/contracts/Interfaces/IXVSVault.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity ^0.8.20;
 
 /// @title IXVSVaultProxy
 /// @author Venus

--- a/contracts/ProtocolReserve/ProtocolShareReserve.sol
+++ b/contracts/ProtocolReserve/ProtocolShareReserve.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import { SafeERC20Upgradeable, IERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
 import { AccessControlledV8 } from "@venusprotocol/governance-contracts/contracts/Governance/AccessControlledV8.sol";

--- a/contracts/ProtocolReserve/RiskFundStorage.sol
+++ b/contracts/ProtocolReserve/RiskFundStorage.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import { Ownable2StepUpgradeable } from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import { ReentrancyGuardUpgradeable } from "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";

--- a/contracts/ProtocolReserve/RiskFundV2.sol
+++ b/contracts/ProtocolReserve/RiskFundV2.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import { IERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import { AccessControlledV8 } from "@venusprotocol/governance-contracts/contracts/Governance/AccessControlledV8.sol";

--- a/contracts/ProtocolReserve/XVSVaultTreasury.sol
+++ b/contracts/ProtocolReserve/XVSVaultTreasury.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import { SafeERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
 import { IERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";

--- a/contracts/Test/Mocks/MockACM.sol
+++ b/contracts/Test/Mocks/MockACM.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import { AccessControl } from "@openzeppelin/contracts/access/AccessControl.sol";
 

--- a/contracts/Test/Mocks/MockArraySorter.sol
+++ b/contracts/Test/Mocks/MockArraySorter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity ^0.8.10;
+pragma solidity ^0.8.20;
 import { sort } from "../../Utils/ArrayHelpers.sol";
 
 contract MockArraySorter {

--- a/contracts/Test/Mocks/MockConverter.sol
+++ b/contracts/Test/Mocks/MockConverter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity ^0.8.10;
+pragma solidity ^0.8.20;
 
 import { SafeERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
 import { IERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";

--- a/contracts/Test/Mocks/MockDeflationaryToken.sol
+++ b/contracts/Test/Mocks/MockDeflationaryToken.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 contract MockDeflatingToken {
     string public constant NAME = "Deflating Test Token";

--- a/contracts/Test/Mocks/MockRiskFundConverter.sol
+++ b/contracts/Test/Mocks/MockRiskFundConverter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import { RiskFundConverter } from "../../TokenConverter/RiskFundConverter.sol";
 

--- a/contracts/Test/imports.sol
+++ b/contracts/Test/imports.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 // This file is needed to make hardhat and typechain generate artifacts for
 // contracts we depend on (e.g. in tests or deployments) but not use directly.

--- a/contracts/TokenConverter/AbstractTokenConverter.sol
+++ b/contracts/TokenConverter/AbstractTokenConverter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import { ReentrancyGuardUpgradeable } from "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
 import { SafeERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";

--- a/contracts/TokenConverter/ConverterNetwork.sol
+++ b/contracts/TokenConverter/ConverterNetwork.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import { AccessControlledV8 } from "@venusprotocol/governance-contracts/contracts/Governance/AccessControlledV8.sol";
 import { MaxLoopsLimitHelper } from "@venusprotocol/solidity-utilities/contracts/MaxLoopsLimitHelper.sol";

--- a/contracts/TokenConverter/IAbstractTokenConverter.sol
+++ b/contracts/TokenConverter/IAbstractTokenConverter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity ^0.8.20;
 
 import { ResilientOracle } from "@venusprotocol/oracle/contracts/ResilientOracle.sol";
 import { IConverterNetwork } from "../Interfaces/IConverterNetwork.sol";

--- a/contracts/TokenConverter/RiskFundConverter.sol
+++ b/contracts/TokenConverter/RiskFundConverter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import { SafeERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
 import { IERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";

--- a/contracts/TokenConverter/SingleTokenConverter.sol
+++ b/contracts/TokenConverter/SingleTokenConverter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import { SafeERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
 import { IERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";

--- a/contracts/Utils/ArrayHelpers.sol
+++ b/contracts/Utils/ArrayHelpers.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 /// @notice Used to sort addresses array based on their token balances
 /// @param arr Array of token balances of different addresses

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -96,7 +96,7 @@ const config: HardhatUserConfig = {
   solidity: {
     compilers: [
       {
-        version: "0.8.13",
+        version: "0.8.20",
         settings: {
           optimizer: {
             enabled: true,


### PR DESCRIPTION
This PR updates the pragma to:

* `^0.8.20` for interfaces, constants, etc.
* `0.8.20` for anything that contains code

Before merging, the dependencies have to be updated after https://github.com/VenusProtocol/solidity-utilities/pull/17, https://github.com/VenusProtocol/governance-contracts/pull/61, and https://github.com/VenusProtocol/oracle/pull/173 are merged.